### PR TITLE
Add SendTimeNanoseconds to Request

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,6 +2,7 @@ package v3io
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/nuclio/logger"
 )
@@ -123,11 +124,12 @@ func (c *Container) sendRequest(input interface{},
 	// create a request/response (TODO: from pool)
 	requestResponse := &RequestResponse{
 		Request: Request{
-			ID:           id,
-			container:    c,
-			Input:        input,
-			Context:      context,
-			responseChan: responseChan,
+			ID:                  id,
+			container:           c,
+			Input:               input,
+			Context:             context,
+			responseChan:        responseChan,
+			SendTimeNanoseconds: time.Now().UnixNano(),
 		},
 	}
 

--- a/types.go
+++ b/types.go
@@ -30,6 +30,9 @@ type Request struct {
 
 	// pointer to container
 	requestResponse *RequestResponse
+
+	// Request time
+	SendTimeNanoseconds int64
 }
 
 type Response struct {


### PR DESCRIPTION
* Add SendTimeNanoseconds to Request to allow measuring request round trip  duration