### PR TITLE
Add option to pass session-key

### DIFF
--- a/context.go
+++ b/context.go
@@ -31,8 +31,12 @@ func NewContext(parentLogger logger.Logger, clusterURL string, numWorkers int) (
 	return newContext, nil
 }
 
-func (c *Context) NewSession(username string, password string, label string) (*Session, error) {
-	return newSession(c.logger, c, username, password, label)
+func (c *Context) NewSession(username string, password string, label string, sessionKey ...string) (*Session, error) {
+	session := ""
+	if len(sessionKey) > 0 {
+		session = sessionKey[0]
+	}
+	return newSession(c.logger, c, username, password, label, session)
 }
 
 func (c *Context) sendRequest(request *Request) error {

--- a/context.go
+++ b/context.go
@@ -11,6 +11,13 @@ type Context struct {
 	numWorkers  int
 }
 
+type SessionConfig struct {
+	Username	string
+	Password	string
+	Label		string
+	SessionKey	string
+}
+
 func NewContext(parentLogger logger.Logger, clusterURL string, numWorkers int) (*Context, error) {
 	newSyncContext, err := newSyncContext(parentLogger, clusterURL)
 	if err != nil {
@@ -31,12 +38,12 @@ func NewContext(parentLogger logger.Logger, clusterURL string, numWorkers int) (
 	return newContext, nil
 }
 
-func (c *Context) NewSession(username string, password string, label string, sessionKey ...string) (*Session, error) {
-	session := ""
-	if len(sessionKey) > 0 {
-		session = sessionKey[0]
-	}
-	return newSession(c.logger, c, username, password, label, session)
+func (c *Context) NewSession(username string, password string, label string) (*Session, error) {
+	return newSession(c.logger, c, username, password, label, "")
+}
+
+func (c *Context) NewSessionFromConfig(sc *SessionConfig) (*Session, error) {
+	return newSession(c.logger, c, sc.Username, sc.Password, sc.Label, sc.SessionKey)
 }
 
 func (c *Context) sendRequest(request *Request) error {

--- a/session.go
+++ b/session.go
@@ -19,9 +19,10 @@ func newSession(parentLogger logger.Logger,
 	context *Context,
 	username string,
 	password string,
-	label string) (*Session, error) {
+	label string,
+	sessionKey string) (*Session, error) {
 
-	newSyncSession, err := newSyncSession(parentLogger, context.Sync, username, password, label)
+	newSyncSession, err := newSyncSession(parentLogger, context.Sync, username, password, label, sessionKey)
 	if err != nil {
 		return nil, err
 	}

--- a/session_key_test.go
+++ b/session_key_test.go
@@ -1,0 +1,58 @@
+package v3io
+
+import (
+	"github.com/nuclio/logger"
+	"github.com/nuclio/zap"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type SessionKeyTestSuite struct {
+	suite.Suite
+	logger  logger.Logger
+	context *Context
+	session *Session
+}
+
+func (suite *SessionKeyTestSuite) SetupTest() {
+	var err error
+
+	suite.logger, err = nucliozap.NewNuclioZapTest("test")
+
+	suite.context, err = NewContext(suite.logger, "<CLUSTER_URL>", 1)
+	suite.Require().NoError(err, "Failed to create context")
+
+	sessionConfig := &SessionConfig{
+		SessionKey: "<SESSION_KEY>",
+	}
+
+	suite.session, err = suite.context.NewSessionFromConfig(sessionConfig)
+	suite.Require().NoError(err, "Failed to create session")
+}
+
+func (suite *SessionKeyTestSuite) TestListAll() {
+
+	dummyContext := "context"
+	responseChan := make(chan *Response, 128)
+
+	request, err := suite.session.ListAll(&ListAllInput{}, &dummyContext, responseChan)
+	suite.Require().NoError(err, "List All returned error")
+	suite.Require().NotNil(request)
+
+	// read a response
+	response := <-responseChan
+
+	// verify there's no error
+	suite.Require().NoError(response.Error)
+
+	output, ok := response.Output.(*ListAllOutput)
+
+	suite.Require().True(ok, "Should have been 'ListAllOutput' got %T", response.Output)
+	suite.Require().True(len(output.Buckets.Bucket) > 0, "Must have at least one bucket")
+
+	response.Release()
+}
+
+func TestSessionKey(t *testing.T) {
+	suite.Run(t, new(SessionKeyTestSuite))
+}


### PR DESCRIPTION
If session-key is passed, it will be used instead of user/password.
Session-key was added as an optional param for the existing NewSession function to keep backward compatibility